### PR TITLE
Update mail.rb

### DIFF
--- a/ext/ruby/addons/mail.rb
+++ b/ext/ruby/addons/mail.rb
@@ -60,4 +60,8 @@ bot.command :writemail do |event, uname, mailname, *content|
    nil
 end
 
+bot.command :help do |event|
+   nil
+end
+
 bot.run


### PR DESCRIPTION
This PR stops Discord.rb's autogenerated help command from overwriting @IpProxyNeon's by custom defining it and making it return `nil`.